### PR TITLE
Alterado a descrição para nome do bot no arquivo ./config/Settings.js

### DIFF
--- a/config/Settings.ts
+++ b/config/Settings.ts
@@ -1,7 +1,7 @@
 import { ISetting, SettingType} from '@rocket.chat/apps-engine/definition/settings';
 
 export enum AppSetting {
-    botpressBotUsername = 'ligerosmart-botpress.bot',
+    botpressBotUsername = 'ligerosmart-botpress_bot',
     botpressServerUrl = 'botpress_server_url',
     botpressBotID = 'botpress_bot_id',
     botpressServiceUnavailableMessage = 'botpress_service_unavailable_message',


### PR DESCRIPTION
O ponto na descrição do nome do bot gera um erro na hora de desinstalar o aplicativo:

![51d09fd1-597a-4c2b-92e2-a5c48ed18087](https://user-images.githubusercontent.com/13037189/152081087-7cdac5e9-0677-43c5-8d55-784acf29aa38.jpeg)
